### PR TITLE
feat(corporaciones): implementar lista de corporaciones para FarmAdmin

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -19,6 +19,7 @@ import { AuthCallbackComponent } from './pages/auth/callback/auth-callback.compo
 import { FinishRegistrationComponent } from './pages/auth/finish-registration/finish-registration.component';
 import { GoogleUserSignupComponent } from './pages/auth/google-signup-user/google-signup-user.component';
 import { GoogleCorporationSignupComponent } from './pages/auth/google-signup-corporation/google-signup-corporation.component';
+import { ListCorporationComponent } from './pages/users/corporation/listCorporations.component';
 
 export const routes: Routes = [
   {
@@ -114,20 +115,18 @@ export const routes: Routes = [
           showInSidebar: false
         }
       },
-
-    /*/  {
-        path: 'profileCorporation',
-        component: ProfileCorporationComponent,
+      {
+        path: 'listCorporation',
+        component: ListCorporationComponent,
         data: { 
           authorities: [
-            IRoleType.admin, 
             IRoleType.superAdmin,
             IRoleType.user
           ],
-          name: 'profileCorporation',
-          showInSidebar: false
+          name: 'Corporaciones',
+          showInSidebar: true
         }
-      },*/
+      },
 
       {
         path: 'games',

--- a/src/app/components/modal/modal.component.scss
+++ b/src/app/components/modal/modal.component.scss
@@ -4,6 +4,7 @@
   justify-content: end;
   border-bottom: none;
   padding-bottom: 0px;
+  background-color: var(--color-bg-main);
 }
 .close {
   background: none;
@@ -28,4 +29,22 @@
 .modal-body {
       max-height: 74vh;
     overflow: auto;
+    background-color: var(--color-bg-main);
+
+    scrollbar-width: thin;
+    scrollbar-color: #7ED957 transparent;
+  
+    &::-webkit-scrollbar {
+      width: 6px;
+    }
+  
+    &::-webkit-scrollbar-thumb {
+      background-color: #7ED957;
+      border-radius: 10px;
+    }
+  
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
 }
+

--- a/src/app/components/user/corporation/coporation-list/corporation-list.component.html
+++ b/src/app/components/user/corporation/coporation-list/corporation-list.component.html
@@ -5,7 +5,6 @@
       <div class="col-sm-12 col-md-6 col-lg-3 mb-4">
         <div class="card-custom">
           
-          <!-- Encabezado con businessName -->
           <div class="card-header-custom">
             <i class="fa-solid fa-user user-icon"></i>
             {{ corporation.businessName }}
@@ -26,14 +25,13 @@
          
           <div class="card-footer-custom">
             <button class="btn-yellow"(click)="callUpdateModalMethod.emit(corporation)">Ver Perfil</button>
-
-            <button class="btn-green">Suscribir</button>
+<!--<button class="btn-green">Suscribir</button>-->
           </div>
         </div>
       </div>
     } @empty {
       <div class="col-12">
-        <p class="text-muted text-center">No hay usuarios corporativos activos o registrados actualmente.</p>
+        <p id="message" class="text-center">No hay usuarios corporativos activos registrados actualmente.</p>
       </div>
     }
   </div>

--- a/src/app/components/user/corporation/coporation-list/corporation-list.component.html
+++ b/src/app/components/user/corporation/coporation-list/corporation-list.component.html
@@ -1,27 +1,40 @@
 <div class="corporation-container mt-4">
-    Lista de usuarios corporativos registros en el sistema
-    <div class="row">
-      @for (corporation of pCorporationList; track corporation) {
-        <div class="col-md-6 col-lg-4 mb-4">
-          <div class="card shadow-sm h-100 border-0 rounded-3">
-            <div class="card-body">
-              <h5 class="card-title fs-6 fw-bold text-primary">Coporaciones: {{ corporation.businessName }}</h5>
-             
-  
-              @if (areActionsAvailable) {
-                <div class="d-flex justify-content-between mt-3">
-                  <button
-                   >Actualizar</button>
-                 
-                </div>
-              }
+  <h1 class="title_center">Corporaciones registradas en el sistema</h1>
+  <div class="row">
+    @for (corporation of pListCorporationList; track corporation) {
+      <div class="col-sm-12 col-md-6 col-lg-3 mb-4">
+        <div class="card-custom">
+          
+          <!-- Encabezado con businessName -->
+          <div class="card-header-custom">
+            <i class="fa-solid fa-user user-icon"></i>
+            {{ corporation.businessName }}
+          </div>
+
+            <div *ngIf="isValidCoordinates(corporation.businessLocation)" #mapContainer class="map-container"></div>
+            <div *ngIf="!isValidCoordinates(corporation.businessLocation)" class="alert alert-warning">
+              <i class="fa-solid fa-triangle-exclamation"></i>
+              Todavía no se ha indicado una ubicación por GPS.
             </div>
+            
+            <div class="card-body-custom pt-3 px-3 pb-2">
+              <p><strong>País:</strong> {{ corporation.businessCountry }}  
+                 <strong>Provincia:</strong> {{ corporation.businessStateProvince }}</p>
+          
+              <p><strong>Identificación:</strong> {{ corporation.businessId }}</p>
+            </div>
+         
+          <div class="card-footer-custom">
+            <button class="btn-yellow"(click)="callUpdateModalMethod.emit(corporation)">Ver Perfil</button>
+
+            <button class="btn-green">Suscribir</button>
           </div>
         </div>
-      } @empty {
-        <div class="col-12">
-          <p class="text-muted text-center">No hay usuarios corporativos activos o registrados actualmente.</p>
-        </div>
-      }
-    </div>
+      </div>
+    } @empty {
+      <div class="col-12">
+        <p class="text-muted text-center">No hay usuarios corporativos activos o registrados actualmente.</p>
+      </div>
+    }
   </div>
+</div>

--- a/src/app/components/user/corporation/coporation-list/corporation-list.component.html
+++ b/src/app/components/user/corporation/coporation-list/corporation-list.component.html
@@ -1,0 +1,27 @@
+<div class="corporation-container mt-4">
+    Lista de usuarios corporativos registros en el sistema
+    <div class="row">
+      @for (corporation of pCorporationList; track corporation) {
+        <div class="col-md-6 col-lg-4 mb-4">
+          <div class="card shadow-sm h-100 border-0 rounded-3">
+            <div class="card-body">
+              <h5 class="card-title fs-6 fw-bold text-primary">Coporaciones: {{ corporation.businessName }}</h5>
+             
+  
+              @if (areActionsAvailable) {
+                <div class="d-flex justify-content-between mt-3">
+                  <button
+                   >Actualizar</button>
+                 
+                </div>
+              }
+            </div>
+          </div>
+        </div>
+      } @empty {
+        <div class="col-12">
+          <p class="text-muted text-center">No hay usuarios corporativos activos o registrados actualmente.</p>
+        </div>
+      }
+    </div>
+  </div>

--- a/src/app/components/user/corporation/coporation-list/corporation-list.component.scss
+++ b/src/app/components/user/corporation/coporation-list/corporation-list.component.scss
@@ -90,3 +90,8 @@
     color: var(--color-btn-primary-text);
     margin-bottom: 20px;
   }
+
+  #message {
+    color: var(--color-warning);
+  }
+  

--- a/src/app/components/user/corporation/coporation-list/corporation-list.component.scss
+++ b/src/app/components/user/corporation/coporation-list/corporation-list.component.scss
@@ -1,0 +1,92 @@
+.card-custom {
+    background-color: var(--card-border);
+    border: 2px solid var(--color-accent);
+    border-radius: 16px;
+    color: var(--color-text-primary);
+    box-shadow: 0 0 10px rgba(76, 175, 80, 0.2);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    &:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+      }
+  }
+  
+  .card-header-custom {
+    background-color: var(--color-accent);
+    color: var(--color-btn-primary-text);
+    font-weight: bold;
+    text-align: center;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    border-top-left-radius: 16px;
+    border-top-right-radius: 16px;
+  }
+  
+  .card-body-custom {
+    color: var(--color-text-secondary);
+    padding: 0.75rem 1rem;
+    font-size: 0.9rem;
+    p {
+      margin-bottom: 0.4rem;
+  
+      strong {
+        color: var(--color-text-primary);
+      }
+    }
+  }
+  
+  .card-footer-custom {
+    display: flex;
+    justify-content: space-between;
+    margin-top: auto;
+    padding: 0 1rem 0.75rem 1rem;
+  }
+  
+  .btn-yellow {
+    background-color: #FFEB3B;
+    color: var(--color-bg-main);
+    border: none;
+    border-radius: 6px;
+    padding: 0.4rem 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+  
+    &:hover {
+      background-color: #FDD835;
+    }
+  }
+  
+  .btn-green {
+    background-color: var(--color-accent);
+    color: var(--color-btn-primary-text);
+    border: none;
+    border-radius: 6px;
+    padding: 0.4rem 0.8rem;
+    font-weight: 600;
+    cursor: pointer;
+  
+    &:hover {
+      background-color: var(--color-btn-primary-hover);
+    }
+  }
+
+  .map-container {
+    height: 150px;
+    width: 100%;
+    border-radius: 0;
+    border-bottom: 1px solid;
+    margin: 0;
+    padding: 0;
+  }
+
+  .title_center {
+    text-align: center;
+    font-weight: bold; 
+    margin-top: 1rem;  
+    color: var(--color-btn-primary-text);
+    margin-bottom: 20px;
+  }

--- a/src/app/components/user/corporation/coporation-list/corporation-list.component.ts
+++ b/src/app/components/user/corporation/coporation-list/corporation-list.component.ts
@@ -31,7 +31,6 @@ export class ListCorporationListComponent implements AfterViewChecked {
     ngAfterViewChecked(): void {
       if (!this.mapsInitialized && this.mapContainers.length > 0) {
         this.mapsInitialized = true;
-        // Espera a que los contenedores estén en el DOM
         setTimeout(() => this.initMaps(), 200);
       }
     }
@@ -46,13 +45,11 @@ export class ListCorporationListComponent implements AfterViewChecked {
         this.mapContainers.forEach((containerRef, index) => {
           const corporation = validCorporations[index];
           if (!corporation) {
-            console.warn('No corporation found for map index:', index);
             return;
           }
       
           const container = containerRef.nativeElement as HTMLElement;
-      
-          // Limpiar contenido previo si se ha creado antes
+
           container.innerHTML = '';
           container.style.height = '150px';
           container.style.width = '100%';
@@ -60,8 +57,6 @@ export class ListCorporationListComponent implements AfterViewChecked {
           const [latStr, lngStr] = corporation.businessLocation!.split(',');
           const lat = parseFloat(latStr);
           const lng = parseFloat(lngStr);
-      
-          console.log(`Initializing map at index ${index} for coords [${lat}, ${lng}]`);
       
           const map = L.map(container).setView([lat, lng], 13);
       
@@ -71,7 +66,7 @@ export class ListCorporationListComponent implements AfterViewChecked {
       
           L.marker([lat, lng]).addTo(map);
       
-          // Muy importante: recalcula el tamaño del mapa después de montar
+          
           setTimeout(() => {
             map.invalidateSize();
           }, 300);

--- a/src/app/components/user/corporation/coporation-list/corporation-list.component.ts
+++ b/src/app/components/user/corporation/coporation-list/corporation-list.component.ts
@@ -1,0 +1,110 @@
+import { AfterViewChecked, AfterViewInit, Component, ElementRef, EventEmitter, inject, Input, Output, QueryList, ViewChildren } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { ICorporation } from "../../../../interfaces/corporation.interface";
+import { AuthService } from "../../../../services/auth.service";
+import * as L from 'leaflet';
+import { ReactiveFormsModule } from "@angular/forms";
+import { CommonModule } from "@angular/common";
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'assets/leaflet/marker-icon-2x.png',
+  iconUrl: 'assets/leaflet/marker-icon.png',
+  shadowUrl: 'assets/leaflet/marker-shadow.png',
+});
+
+@Component({
+  selector: "app-listCorporation-list",
+  templateUrl: "./corporation-list.component.html",
+  styleUrls: ["./corporation-list.component.scss"],
+  standalone: true,
+    imports: [
+      ReactiveFormsModule,
+      CommonModule
+    ]
+})
+export class ListCorporationListComponent implements AfterViewChecked {
+
+    @ViewChildren('mapContainer', { read: ElementRef }) mapContainers!: QueryList<ElementRef>;
+
+    private mapsInitialized = false;
+    ngAfterViewChecked(): void {
+      if (!this.mapsInitialized && this.mapContainers.length > 0) {
+        this.mapsInitialized = true;
+        // Espera a que los contenedores estén en el DOM
+        setTimeout(() => this.initMaps(), 200);
+      }
+    }
+      get corporationsWithValidLocation(): ICorporation[] {
+
+        return this.pListCorporationList.filter(c => this.isValidCoordinates(c.businessLocation));
+      }
+      
+      private initMaps(): void {
+        const validCorporations = this.pListCorporationList.filter(c => this.isValidCoordinates(c.businessLocation));
+      
+        this.mapContainers.forEach((containerRef, index) => {
+          const corporation = validCorporations[index];
+          if (!corporation) {
+            console.warn('No corporation found for map index:', index);
+            return;
+          }
+      
+          const container = containerRef.nativeElement as HTMLElement;
+      
+          // Limpiar contenido previo si se ha creado antes
+          container.innerHTML = '';
+          container.style.height = '150px';
+          container.style.width = '100%';
+      
+          const [latStr, lngStr] = corporation.businessLocation!.split(',');
+          const lat = parseFloat(latStr);
+          const lng = parseFloat(lngStr);
+      
+          console.log(`Initializing map at index ${index} for coords [${lat}, ${lng}]`);
+      
+          const map = L.map(container).setView([lat, lng], 13);
+      
+          L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; OpenStreetMap contributors'
+          }).addTo(map);
+      
+          L.marker([lat, lng]).addTo(map);
+      
+          // Muy importante: recalcula el tamaño del mapa después de montar
+          setTimeout(() => {
+            map.invalidateSize();
+          }, 300);
+        });
+      }
+      ngOnDestroy(): void {
+        this.mapsInitialized = false;
+      }
+      
+      isValidCoordinates(location: string | null | undefined): boolean {
+        if (!location) return false;
+      
+        const coords = location.split(',');
+        if (coords.length !== 2) return false;
+      
+        const lat = parseFloat(coords[0]);
+        const lng = parseFloat(coords[1]);
+      
+        return !isNaN(lat) && !isNaN(lng) && Math.abs(lat) <= 90 && Math.abs(lng) <= 180;
+      }
+      
+  @Input() pListCorporationList: ICorporation[] = [];
+  @Output() callUpdateModalMethod: EventEmitter<ICorporation> = new EventEmitter<ICorporation>();
+  @Output() callDeleteMethod: EventEmitter<ICorporation> = new EventEmitter<ICorporation>();
+  public authService: AuthService = inject(AuthService);
+  public areActionsAvailable: boolean = false;
+  public route: ActivatedRoute = inject(ActivatedRoute);
+
+  ngOnInit(): void {
+    this.authService.getUserAuthorities();
+    this.route.data.subscribe( data => {
+      this.areActionsAvailable = this.authService.areActionsAvailable(data['authorities'] ? data['authorities'] : []);
+    });
+  }
+
+}

--- a/src/app/components/user/corporation/coporation-list/corporationView.component.html
+++ b/src/app/components/user/corporation/coporation-list/corporationView.component.html
@@ -1,5 +1,51 @@
-<div class="container-form-wrapper">
+<div class="header-bar">
+  <i class="bi bi-building"></i>
+  <h2>{{ form.get('businessName')?.value || 'No disponible' }}</h2>
+</div>
 
+<div class="info-container">
+  <div class="col-6">
+    <div class="body">
 
+      <label>Identificación Empresarial:</label>
+      <p>{{ form.get('businessId')?.value || 'No disponible' }}</p>
+
+      <label>Misión:</label>
+      <p>{{ form.get('businessMission')?.value || 'No disponible' }}</p>
+
+      <label>Visión:</label>
+      <p>{{ form.get('businessVision')?.value || 'No disponible' }}</p>
+
+      <label>Correo Electrónico:</label>
+      <p>{{ form.get('userEmail')?.value || 'No disponible' }}</p>
+    </div>
   </div>
-  
+
+  <div class="col-6">
+    <div class="body">
+      <label>País:</label>
+      <p>{{ form.get('businessCountry')?.value || 'No disponible' }}</p>
+
+      <label>Provincia:</label>
+      <p>{{ form.get('businessStateProvince')?.value || 'No disponible' }}</p>
+
+      <label>Otras Direcciones:</label>
+      <p>{{ form.get('businessOtherDirections')?.value || 'No disponible' }}</p>
+
+      <label>Coordenadas:</label>
+      <p>{{ form.get('businessLocation')?.value || 'No disponible' }}</p>
+    </div>
+  </div>
+</div>
+
+<div class="map-section">
+  <p class="map-label">Localización por GPS</p>
+
+  <div *ngIf="isValidCoordinates(form.get('businessLocation')?.value)" id="map" class="map-container"></div>
+
+  <div *ngIf="!isValidCoordinates(form.get('businessLocation')?.value)" class="alert alert-warning">
+    <i class="fa-solid fa-triangle-exclamation"></i>
+    Todavía no se ha indicado una ubicación por GPS.
+  </div>
+
+</div>

--- a/src/app/components/user/corporation/coporation-list/corporationView.component.html
+++ b/src/app/components/user/corporation/coporation-list/corporationView.component.html
@@ -1,0 +1,5 @@
+<div class="container-form-wrapper">
+
+
+  </div>
+  

--- a/src/app/components/user/corporation/coporation-list/corporationView.component.scss
+++ b/src/app/components/user/corporation/coporation-list/corporationView.component.scss
@@ -1,0 +1,93 @@
+:host {
+    display: block;
+    background-color: #1E1E1E;
+    min-height: 100vh;
+    padding: 2rem;
+    color: white;
+    font-family: Arial, sans-serif;
+  }
+  
+  .header-bar {
+    background-color: #4CAF50;
+    border-radius: 8px;
+    padding: 1.5rem 2rem;
+    margin-bottom: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+  
+    i {
+      color: #1E1E1E;
+      font-size: 1.75rem;
+    }
+  
+    h2 {
+      margin: 0;
+      font-size: 2rem;
+      color: white;
+      font-weight: bold;
+    }
+  }
+  
+  .info-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+  
+    .col-6 {
+      flex: 1;
+      min-width: 320px;
+    }
+  
+    .body {
+      background-color: #1E1E1E;
+      border: 1px solid #7ED957;
+      border-radius: 12px;
+      padding: 2rem;
+  
+      label {
+        color: #7ED957;
+        font-weight: bold;
+        font-size: 1.05rem;
+        display: block;
+        margin-bottom: 0.25rem;
+      }
+  
+      p {
+        color: #E0E0E0;
+        font-size: 1rem;
+        margin-bottom: 1rem;
+        border-bottom: 1px solid #ccc;
+        padding-bottom: 0.5rem;
+      }
+    }
+  }
+  
+  .map-section {
+    text-align: center;
+    margin-top: 3rem;
+  
+    .map-label {
+      font-weight: bold;
+      color: #ffffff;
+      margin-bottom: 0.5rem;
+    }
+  
+    .coordinates {
+      font-size: 0.95rem;
+      color: #dddddd;
+      margin-bottom: 1rem;
+    }
+  
+    .map-container {
+      width: 90%;
+      max-width: 700px;
+      height: 300px;
+      margin: 0 auto;
+      border: 2px solid #7ED957;
+      border-radius: 12px;
+      background-color: #2c2c2c;
+    }
+  }
+  

--- a/src/app/components/user/corporation/coporation-list/corporationView.component.ts
+++ b/src/app/components/user/corporation/coporation-list/corporationView.component.ts
@@ -16,7 +16,7 @@ L.Icon.Default.mergeOptions({
 @Component({
   selector: "app-corporation-view",
   templateUrl: "./corporationView.component.html",
-  //styleUrls: ["./corporationView.component.scss"],
+  styleUrls: ["./corporationView.component.scss"],
   standalone: true,
   imports: [
     ReactiveFormsModule,
@@ -26,23 +26,41 @@ L.Icon.Default.mergeOptions({
 export class CorporationViewComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
-    const map = L.map('map').setView([10.0, -84.0], 7);
-
+    const formData = this.form.getRawValue();
+    const location = formData.businessLocation;
+  
+    if (!this.isValidCoordinates(location)) return;
+  
+    const [latStr, lngStr] = location.split(',');
+    const lat = parseFloat(latStr);
+    const lng = parseFloat(lngStr);
+  
+    const map = L.map('map').setView([lat, lng], 13);
+  
+    console.log(`Initializing map at index for coords [${lat}, ${lng}]`);
+  
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; OpenStreetMap contributors'
     }).addTo(map);
+  
+    L.marker([lat, lng]).addTo(map);
 
-    const marker = L.marker([10.0, -84.0], { draggable: true }).addTo(map);
-
-    marker.on('dragend', () => {
-      const position = marker.getLatLng();
-      this.form.controls['businessLocation'].setValue(`${position.lat.toFixed(6)},${position.lng.toFixed(6)}`);
-    });
     setTimeout(() => {
       map.invalidateSize();
     }, 300);
   }
-
+  
+  isValidCoordinates(location: string | null | undefined): boolean {
+    if (!location) return false;
+  
+    const coords = location.split(',');
+    if (coords.length !== 2) return false;
+  
+    const lat = parseFloat(coords[0]);
+    const lng = parseFloat(coords[1]);
+  
+    return !isNaN(lat) && !isNaN(lng) && Math.abs(lat) <= 90 && Math.abs(lng) <= 180;
+  }
   public fb: FormBuilder = inject(FormBuilder);
   @Input() form!: FormGroup;
   @Output() callSaveMethod: EventEmitter<ICorporation> = new EventEmitter<ICorporation>();
@@ -64,18 +82,7 @@ export class CorporationViewComponent implements AfterViewInit {
       businessStateProvince: formData.businessStateProvince,
       businessOtherDirections: formData.businessOtherDirections,
       businessLocation: formData.businessLocation,
-      userName: formData.userName,
-      userFirstSurename: formData.userFirstSurename,
-      userSecondSurename: formData.userSecondSurename,
-      userGender: formData.userGender,
-      userPhoneNumber: formData.userPhoneNumber,
-      userEmail: formData.userEmail,
-      userPassword: formData.userPassword || null,
-      role: {
-        id: 3,
-        roleName: "CORPORATION"
-      },
-      isActive: formData.isActive !== undefined ? formData.isActive : true
+      userEmail: formData.userEmail
     }
 
 

--- a/src/app/components/user/corporation/coporation-list/corporationView.component.ts
+++ b/src/app/components/user/corporation/coporation-list/corporationView.component.ts
@@ -1,0 +1,94 @@
+import { AfterViewInit, Component, EventEmitter, inject, Input, Output } from "@angular/core";
+import { FormBuilder, FormGroup, ReactiveFormsModule } from "@angular/forms";
+import { CommonModule } from "@angular/common";
+import { ICorporation } from "../../../../interfaces/corporation.interface";
+import * as L from 'leaflet';
+import { CountryEnum, ProvinceEnum } from "../../../../enums/location.enum";
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'assets/leaflet/marker-icon-2x.png',
+  iconUrl: 'assets/leaflet/marker-icon.png',
+  shadowUrl: 'assets/leaflet/marker-shadow.png',
+});
+
+
+@Component({
+  selector: "app-corporation-view",
+  templateUrl: "./corporationView.component.html",
+  //styleUrls: ["./corporationView.component.scss"],
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    CommonModule
+  ],
+})
+export class CorporationViewComponent implements AfterViewInit {
+
+  ngAfterViewInit(): void {
+    const map = L.map('map').setView([10.0, -84.0], 7);
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    const marker = L.marker([10.0, -84.0], { draggable: true }).addTo(map);
+
+    marker.on('dragend', () => {
+      const position = marker.getLatLng();
+      this.form.controls['businessLocation'].setValue(`${position.lat.toFixed(6)},${position.lng.toFixed(6)}`);
+    });
+    setTimeout(() => {
+      map.invalidateSize();
+    }, 300);
+  }
+
+  public fb: FormBuilder = inject(FormBuilder);
+  @Input() form!: FormGroup;
+  @Output() callSaveMethod: EventEmitter<ICorporation> = new EventEmitter<ICorporation>();
+  @Output() callUpdateMethod: EventEmitter<ICorporation> = new EventEmitter<ICorporation>();
+  countryEnum = CountryEnum;
+  provinceEnum = ProvinceEnum;
+  countries = Object.values(CountryEnum);
+  provinces = Object.values(ProvinceEnum);
+  callSave() {
+    const formData = this.form.getRawValue();
+
+    let item: ICorporation = {
+      id: formData.id,
+      businessName: formData.businessName,
+      businessMission: formData.businessMission,
+      businessVision: formData.businessVision,
+      businessId: formData.businessId,
+      businessCountry: formData.businessCountry,
+      businessStateProvince: formData.businessStateProvince,
+      businessOtherDirections: formData.businessOtherDirections,
+      businessLocation: formData.businessLocation,
+      userName: formData.userName,
+      userFirstSurename: formData.userFirstSurename,
+      userSecondSurename: formData.userSecondSurename,
+      userGender: formData.userGender,
+      userPhoneNumber: formData.userPhoneNumber,
+      userEmail: formData.userEmail,
+      userPassword: formData.userPassword || null,
+      role: {
+        id: 3,
+        roleName: "CORPORATION"
+      },
+      isActive: formData.isActive !== undefined ? formData.isActive : true
+    }
+
+
+    if (this.form.controls['id'].value) {
+      item.id = this.form.controls['id'].value;
+    }
+    if (item.id) {
+      this.callUpdateMethod.emit(item);
+    } else {
+      this.callSaveMethod.emit(item);
+    }
+
+  }
+
+
+}

--- a/src/app/pages/users/corporation/corporation.component.ts
+++ b/src/app/pages/users/corporation/corporation.component.ts
@@ -89,4 +89,14 @@ export const passwordMatchValidator: ValidatorFn = (form: AbstractControl): Vali
           }
         });
       }
+
+      openEditListCorporationModal(corporation: ICorporation) {
+        console.log("openEditListCorporationModal", corporation);
+        this.corporationForm.patchValue({
+          id: JSON.stringify(corporation.id),
+          businessName: corporation.businessName
+        });
+        this.modalService.displayModal('lg', this.editCorporationModal);
+      }
+
   }

--- a/src/app/pages/users/corporation/listCorporations.component.html
+++ b/src/app/pages/users/corporation/listCorporations.component.html
@@ -1,8 +1,22 @@
-
 @if (areActionsAvailable) {
   <app-listCorporation-list
   [pListCorporationList]="listCorporationService.listCorporation$()"
   (callUpdateModalMethod)="openEditListCorporationModal($event)"
 />
-}
 
+<ng-template #editListCorporationModal>
+  <app-modal [hideFooter]="true">
+    <div class="modal-content-custom dark-theme-modal">
+      <div class="modal-header-custom">
+        <button class="close-button" (click)="closeEditListCorporationModal()">
+          <i class="fas fa-times"></i> Cerrar
+        </button>
+      </div>
+
+      <div class="modal-body-custom">
+        <app-corporation-view [form]="listCorporationForm" />
+      </div>
+    </div>
+  </app-modal>
+</ng-template>
+}

--- a/src/app/pages/users/corporation/listCorporations.component.html
+++ b/src/app/pages/users/corporation/listCorporations.component.html
@@ -1,0 +1,8 @@
+
+@if (areActionsAvailable) {
+  <app-listCorporation-list
+  [pListCorporationList]="listCorporationService.listCorporation$()"
+  (callUpdateModalMethod)="openEditListCorporationModal($event)"
+/>
+}
+

--- a/src/app/pages/users/corporation/listCorporations.component.scss
+++ b/src/app/pages/users/corporation/listCorporations.component.scss
@@ -1,0 +1,16 @@
+
+
+.close-button {
+    background: none;
+    border: none;
+    color: #ffffff;
+    font-size: 1rem;
+    font-weight: bold;
+    float: right;
+    cursor: pointer;
+    transition: color 0.3s ease;
+  
+    &:hover {
+      color: #ff6666;
+    }
+  }

--- a/src/app/pages/users/corporation/listCorporations.component.ts
+++ b/src/app/pages/users/corporation/listCorporations.component.ts
@@ -1,0 +1,65 @@
+
+import { Component, EventEmitter, inject, Output, ViewChild } from "@angular/core";
+import { FormBuilder, Validators } from "@angular/forms";
+import { ActivatedRoute } from '@angular/router';
+import { PaginationComponent } from "../../../components/pagination/pagination.component";
+import { ModalComponent } from "../../../components/modal/modal.component";
+import { ICorporation } from "../../../interfaces/corporation.interface";
+import { ListCorporationService } from "../../../services/listCorporations.service";
+import { ModalService } from "../../../services/modal.service";
+import { AuthService } from "../../../services/auth.service";
+import { ListCorporationListComponent } from "../../../components/user/corporation/coporation-list/corporation-list.component";
+import { CorporationViewComponent } from "../../../components/user/corporation/coporation-list/corporationView.component";
+
+@Component({
+  selector: "app-listCorporation",
+  templateUrl: "./listCorporations.component.html",
+ // styleUrls: ["./listCorporation.component.scss"],
+  standalone: true,
+  imports: [
+    CorporationViewComponent,
+    ListCorporationListComponent,
+    PaginationComponent,
+    ModalComponent
+  ]
+})
+export class ListCorporationComponent {
+  public listCorporationList: ICorporation[] = []
+  public listCorporationService: ListCorporationService = inject(ListCorporationService);
+  public fb: FormBuilder = inject(FormBuilder);
+  public listCorporationForm = this.fb.group({
+    id: [''],
+    businessName: ['', Validators.required],
+    businessMission: ['', Validators.required],
+  });
+  public modalService: ModalService = inject(ModalService);
+  @ViewChild('editListCorporationModal') public editListCorporationModal: any;
+  @Output() callUpdateModalMethod: EventEmitter<ICorporation> = new EventEmitter<ICorporation>();
+
+  public authService: AuthService = inject(AuthService);
+  public areActionsAvailable: boolean = false;
+  public route: ActivatedRoute = inject(ActivatedRoute);
+
+  ngOnInit(): void {
+    this.authService.getUserAuthorities();
+    this.route.data.subscribe( data => {
+      this.areActionsAvailable = this.authService.areActionsAvailable(data['authorities'] ? data['authorities'] : []);
+    });
+  }
+
+  constructor() {
+    this.listCorporationService.getAll();
+  }
+
+
+  openEditListCorporationModal(listCorporation: ICorporation) {
+    console.log("x openEditListCorporationModal", listCorporation);
+    this.listCorporationForm.patchValue({
+      id: JSON.stringify(listCorporation.id),
+      businessName: listCorporation.businessName,
+      businessMission: listCorporation.businessMission
+    });
+    this.modalService.displayModal('lg', this.editListCorporationModal);
+  }
+
+}

--- a/src/app/pages/users/corporation/listCorporations.component.ts
+++ b/src/app/pages/users/corporation/listCorporations.component.ts
@@ -1,5 +1,5 @@
 
-import { Component, EventEmitter, inject, Output, ViewChild } from "@angular/core";
+import { Component, EventEmitter, inject, Output, TemplateRef, ViewChild } from "@angular/core";
 import { FormBuilder, Validators } from "@angular/forms";
 import { ActivatedRoute } from '@angular/router';
 import { PaginationComponent } from "../../../components/pagination/pagination.component";
@@ -10,11 +10,12 @@ import { ModalService } from "../../../services/modal.service";
 import { AuthService } from "../../../services/auth.service";
 import { ListCorporationListComponent } from "../../../components/user/corporation/coporation-list/corporation-list.component";
 import { CorporationViewComponent } from "../../../components/user/corporation/coporation-list/corporationView.component";
+import { NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
 
 @Component({
   selector: "app-listCorporation",
   templateUrl: "./listCorporations.component.html",
- // styleUrls: ["./listCorporation.component.scss"],
+  styleUrls: ["./listCorporations.component.scss"],
   standalone: true,
   imports: [
     CorporationViewComponent,
@@ -24,13 +25,22 @@ import { CorporationViewComponent } from "../../../components/user/corporation/c
   ]
 })
 export class ListCorporationComponent {
+  @ViewChild('editListCorporationModal') editModalTemplate!: TemplateRef<any>;
   public listCorporationList: ICorporation[] = []
   public listCorporationService: ListCorporationService = inject(ListCorporationService);
   public fb: FormBuilder = inject(FormBuilder);
   public listCorporationForm = this.fb.group({
-    id: [''],
-    businessName: ['', Validators.required],
-    businessMission: ['', Validators.required],
+      id: [''],
+      businessName: ['', Validators.required],
+      businessMission: ['', Validators.required],
+      businessVision: ['', Validators.required],
+      businessId: ['', Validators.required],
+      businessCountry: ['Costa Rica', Validators.required],
+      businessStateProvince: ['', Validators.required],
+      businessOtherDirections: [''],
+      businessLocation: [''],
+      userEmail: ['', Validators.required]
+
   });
   public modalService: ModalService = inject(ModalService);
   @ViewChild('editListCorporationModal') public editListCorporationModal: any;
@@ -50,14 +60,25 @@ export class ListCorporationComponent {
   constructor() {
     this.listCorporationService.getAll();
   }
+  showModal = false;
 
-
+  closeEditListCorporationModal(): void {
+    this.modalService.closeAll();
+  }
+  
   openEditListCorporationModal(listCorporation: ICorporation) {
     console.log("x openEditListCorporationModal", listCorporation);
     this.listCorporationForm.patchValue({
       id: JSON.stringify(listCorporation.id),
+      businessId: listCorporation.businessId,
       businessName: listCorporation.businessName,
-      businessMission: listCorporation.businessMission
+      businessMission: listCorporation.businessMission,
+      businessVision: listCorporation.businessVision,
+      businessCountry: listCorporation.businessCountry,
+      businessStateProvince: listCorporation.businessStateProvince,
+      businessOtherDirections: listCorporation.businessOtherDirections,
+      businessLocation: listCorporation.businessLocation,
+      userEmail: listCorporation.userEmail
     });
     this.modalService.displayModal('lg', this.editListCorporationModal);
   }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -126,8 +126,8 @@ export class AuthService {
       if (allowedUser) break;
     }
     // se valida que el usuario tenga un rol de administración
-    if (userAuthorities?.some(item => item.authority == IRoleType.admin || item.authority == IRoleType.superAdmin)) {
-      isAdmin = userAuthorities?.some(item => item.authority == IRoleType.admin || item.authority == IRoleType.superAdmin);
+    if (userAuthorities?.some(item => item.authority == IRoleType.admin || item.authority == IRoleType.user)) {
+      isAdmin = userAuthorities?.some(item => item.authority == IRoleType.admin || item.authority == IRoleType.user);
     }
     return allowedUser && isAdmin;
   }

--- a/src/app/services/listCorporations.service.ts
+++ b/src/app/services/listCorporations.service.ts
@@ -1,6 +1,5 @@
 import { inject, Injectable, signal } from '@angular/core';
 import { IResponse, ISearch} from '../interfaces';
-import { AlertService } from './alert.service';
 import { BaseService } from './base-service';
 import { ICorporation } from '../interfaces/corporation.interface';
 
@@ -20,7 +19,6 @@ import { ICorporation } from '../interfaces/corporation.interface';
     }
   
     public totalItems: any = [];
-    private alertService: AlertService = inject(AlertService);
   
     getAll () {
       this.findAllWithParams({ page: this.search.page, size: this.search.size }).subscribe({

--- a/src/app/services/listCorporations.service.ts
+++ b/src/app/services/listCorporations.service.ts
@@ -1,0 +1,39 @@
+import { inject, Injectable, signal } from '@angular/core';
+import { IResponse, ISearch} from '../interfaces';
+import { AlertService } from './alert.service';
+import { BaseService } from './base-service';
+import { ICorporation } from '../interfaces/corporation.interface';
+
+@Injectable({
+    providedIn: 'root'
+  })
+
+  export class ListCorporationService  extends BaseService<ICorporation>{
+    protected override source: string = 'users/listcorporations';
+    private listCorporationSignal = signal<ICorporation[]>([]);
+    get listCorporation$() {
+      return this.listCorporationSignal;
+    }
+    public search: ISearch = { 
+      page: 1,
+      size: 5
+    }
+  
+    public totalItems: any = [];
+    private alertService: AlertService = inject(AlertService);
+  
+    getAll () {
+      this.findAllWithParams({ page: this.search.page, size: this.search.size }).subscribe({
+        next: (response: IResponse<ICorporation[]>) => {
+          this.search = { ...this.search, ...response.meta };
+          this.totalItems = Array.from({ length: this.search.totalPages ? this.search.totalPages : 0 }, (_, i) => i + 1);
+          this.listCorporationSignal.set(response.data);
+        },
+        error: (err: any) => {
+          console.error('error', err);
+        }
+      });
+    }
+
+  
+  }


### PR DESCRIPTION
Se agregó la funcionalidad para mostrar la lista de corporaciones con su respectivo diseño, lógica de carga de datos y eventos de interacción.
-Incluye integración con el backend y vista responsive en forma de cards.
-Se implementa opción en el menú del Dashboard, la cual solo es visible para usuarios FarmAdmin
-Se implementó Modal en la opción de ver perfil
-Se implementó corporationView.component.ts para la gestión del modal
-Se corrigieron estilos del modal y botones