### PR TITLE
fix(editarPerfil): Ajustes minimos en EditarPerfil

### DIFF
--- a/src/app/components/my-account/my-account.component.ts
+++ b/src/app/components/my-account/my-account.component.ts
@@ -18,7 +18,7 @@ export class MyAccountComponent implements OnInit {
     let user = localStorage.getItem('auth_user');
     if(user) {
       this.userName = JSON.parse(user)?.name;
-      if(this.userName == null)
+      if(!this.userName?.trim())
       {
         this.userName = JSON.parse(user)?.businessName;
       }

--- a/src/app/pages/profile/profile.component.html
+++ b/src/app/pages/profile/profile.component.html
@@ -263,13 +263,13 @@
 <!-- Mapa -->
 <div class="map-wrapper mt-4">
   <div class="d-flex justify-content-between align-items-center mb-2">
-    <label>Localización por GPS</label>
+    <label>Localización por Mapa</label>
     <i class="fa fa-pen edit-icon" title="Editar ubicación" (click)="enableMapEditing()" *ngIf="hasValidLocation"></i>
   </div>
   <label>Coordenadas actuales: {{ editableUser.businessLocation || 'No se ha indicado...' }}</label>
   <div id="map" class="map-container" [ngClass]="{ 'd-none': !hasValidLocation }"></div>
   <p *ngIf="!hasValidLocation" class="no-location-msg d-flex justify-content-between align-items-center">
-    <span>Todavía no se ha indicado una ubicación por GPS.</span>
+    <span>Todavía no se ha indicado una ubicación en mapa.</span>
     <button class="btn btn-outline-success btn-sm ms-2"
     style="border-color: #4CAF50;"
     (click)="initMapForEmptyLocation()"

--- a/src/app/pages/profile/profile.component.ts
+++ b/src/app/pages/profile/profile.component.ts
@@ -58,8 +58,7 @@ updateErrorStatus(): void {
 
   f['businessCountry'] = !u.businessCountry?.trim();
   f['businessStateProvince'] = !u.businessStateProvince?.trim();
-  f['businessOtherDirections'] = !u.businessOtherDirections?.trim();
-
+  f['businessOtherDirections'] = false;
   if (role === 'CORPORATION') {
     f['businessName'] = !u.businessName?.trim();
     f['businessMission'] = !u.businessMission?.trim();
@@ -81,6 +80,10 @@ updateErrorStatus(): void {
 
     effect(() => {
       const user = this.profileService.user$();
+
+      if (!user.businessCountry?.trim()) {//en caso de que se registre nulo en la bd
+        user.businessCountry = CountryEnum.COSTA_RICA;
+      }
       this.editableUser = { ...user };
       this.originalUser = { ...user };
 
@@ -209,6 +212,9 @@ updateErrorStatus(): void {
 
   updateProfile() {
     const u = this.editableUser;
+    if (!u.businessCountry?.trim()) {
+      u.businessCountry = CountryEnum.COSTA_RICA;
+    }
     const myUser: IUser = {
       id: u.id,
       name: u.name,


### PR DESCRIPTION
-Ajuste en nombre del perfil de mi cuenta (ahora ya sale el nombre del usuario corporativo porque antes solo salia el nombre de la cuenta de usuarios farmAdmin)
-Se autocompleta campo businessCountry a Costa Rica (enum), ya que la aplicación solo posee dicho pais.
-Se corrige bug del campo businessOtherDirections en el cual si estaba vacio y los demás campos si estan completos, no se dejaba actualizar el perfil, debido a que no es obligatorio, se corrigió para permita actualizar los datos del perfil aunque esté vacio.
